### PR TITLE
fix(telescope): make border fg & bg same

### DIFF
--- a/lua/nordic/groups/integrations/telescope.lua
+++ b/lua/nordic/groups/integrations/telescope.lua
@@ -7,6 +7,7 @@ return {
     },
 
     TelescopePromptBorder = {
+        fg = c.gray1,
         bg = c.gray1
     },
 
@@ -15,6 +16,7 @@ return {
     },
 
     TelescopeResultsBorder = {
+        fg = c.black,
         bg = c.black
     },
 
@@ -23,6 +25,7 @@ return {
     },
 
     TelescopePreviewBorder = {
+        fg = c.black,
         bg = c.black
     },
 


### PR DESCRIPTION
To achieve the same result as in README screenshot 
### Before
<img width="1486" alt="Screenshot 2023-01-23 at 7 39 59 AM" src="https://user-images.githubusercontent.com/327489/213947052-cfc23dad-f5e8-4ba2-9bb0-4a824f15f490.png">

### After
<img width="1486" alt="Screenshot 2023-01-23 at 7 48 46 AM" src="https://user-images.githubusercontent.com/327489/213947086-eb47601e-986a-4561-b416-6b23777ed96b.png">
