### PR TITLE
Feat: Border brightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ require 'nordic' .setup {
     italic_comments = true,
     -- Enable general editor background transparency.
     transparent_bg = false,
+    -- Enable bright border
+    bright_border = true,
     -- Nordic specific options.
     -- Set all to false to use original Nord colors.
     -- Adjusts some colors to make the theme a bit nicer (imo).

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ require 'nordic' .setup {
     italic_comments = true,
     -- Enable general editor background transparency.
     transparent_bg = false,
-    -- Enable bright border
+    -- Enable brighter float border.
     bright_border = true,
     -- Nordic specific options.
     -- Set all to false to use original Nord colors.

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -39,7 +39,7 @@ palette.fg_selected = palette.fg_bright
 
 -- Borders.
 palette.border = palette.black
-palette.border_float = palette.white1
+palette.border_float = palette.gray4
 palette.border_nb = palette.orange.base
 
 -- Diffs.

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -39,7 +39,7 @@ palette.fg_selected = palette.fg_bright
 
 -- Borders.
 palette.border = palette.black
-palette.border_float = palette.gray4
+palette.border_float = o.bright_border and palette.white1 or palette.gray4
 palette.border_nb = palette.orange.base
 
 -- Diffs.

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -39,7 +39,7 @@ palette.fg_selected = palette.fg_bright
 
 -- Borders.
 palette.border = palette.black
-palette.border_float = o.bright_border and palette.white1 or palette.gray4
+palette.border_float = (o.bright_border and palette.white0) or palette.gray4
 palette.border_nb = palette.orange.base
 
 -- Diffs.

--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -9,6 +9,8 @@ M.defaults = {
     italic_comments = true,
     -- Enable general editor background transparency.
     transparent_bg = false,
+    -- Enable bright border
+    bright_border = true,
     -- Nordic specific options.
     -- Set all to false to use original Nord colors.
     -- Adjusts some colors to make the theme a bit nicer (imo).

--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -9,7 +9,7 @@ M.defaults = {
     italic_comments = true,
     -- Enable general editor background transparency.
     transparent_bg = false,
-    -- Enable bright border
+    -- Enable brighter float border.
     bright_border = true,
     -- Nordic specific options.
     -- Set all to false to use original Nord colors.

--- a/lua/nordic/tests/options.lua
+++ b/lua/nordic/tests/options.lua
@@ -17,5 +17,6 @@ config.cursorline.hide_unfocused = false
 config.noice.style = 'flat'
 config.telescope.style = 'classic'
 config.leap.dim_backdrop = true
+config.bright_border = false
 
 load(config)


### PR DESCRIPTION
I propose using a more dim color for FloatBorder so it does not distract an eye from the contents of a floating window.

Before:
![Screenshot 2023-04-02 020900](https://user-images.githubusercontent.com/61948252/229320465-f2bdea2e-dc54-43b8-9359-2d6d734eb59d.png)
After:
![Screenshot 2023-04-02 021124](https://user-images.githubusercontent.com/61948252/229320481-80cc4724-f848-4d04-b0e9-26caeecdc325.png)

Before:
![Screenshot 2023-04-02 021158](https://user-images.githubusercontent.com/61948252/229320601-61c4306f-3b4a-40b3-9f45-a4bc923e7c22.png)
After:
![Screenshot 2023-04-02 021140](https://user-images.githubusercontent.com/61948252/229320615-a42a6be7-b660-4fb4-ae58-d7c8ba2409d0.png)