### PR TITLE
Fix(utils): Handle case where we try to blend 'NONE'

### DIFF
--- a/lua/nordic/utils.lua
+++ b/lua/nordic/utils.lua
@@ -107,6 +107,10 @@ end
 
 -- Adapted from @folke/tokyonight.nvim.
 function M.blend(foreground, background, alpha)
+    if foreground == 'NONE' or background == 'NONE' then
+        return 'NONE'
+    end
+
     local fg = { M.hex_to_rgb(foreground) }
     local bg = { M.hex_to_rgb(background) }
 


### PR DESCRIPTION
Discussed in #48, introduced in #97.  

Why did the tests not catch it?