### PR TITLE
feat(highlights): Added some missed highlights primarily for markup languages

### DIFF
--- a/lua/nordic/groups/integrations.lua
+++ b/lua/nordic/groups/integrations.lua
@@ -326,7 +326,7 @@ function M.get_groups()
     G['@variable.builtin'] = { link = 'Builtin' } -- Variable names that are defined by the languages, like `this` or `self`.
     G['@variable.member'] = { link = 'Field' }
     --- Text
-     G['@spell'] = { link = 'Comment' }
+    -- G['@spell'] = { link = 'Comment' } -- This seems to interfere with regular text
     -- G["@text.literal.markdown"] = { }
     G['@text'] = { link = 'Normal' } -- For strings considered text in a markup language.
     G['@text.strong'] = { bold = true }

--- a/lua/nordic/groups/integrations.lua
+++ b/lua/nordic/groups/integrations.lua
@@ -280,6 +280,12 @@ function M.get_groups()
     G['@comment'] = { link = 'Comment' }
     --G['@comment.documentation'] = { link = 'Comment' }
     G['@comment.documentation'] = { link = 'Comment' }
+    G["@comment.note"] = { fg = C.hint }
+    G["@comment.error"] = { fg = C.error }
+    G["@comment.hint"] = { fg = C.hint }
+    G["@comment.info"] = { fg = C.info }
+    G["@comment.warning"] = { fg = C.warning }
+    G["@comment.todo"] = { fg = C.todo }
     G['@operator'] = { fg = C.fg } -- For any operator: `+`, but also `->` and `*` in C.
     --- Punctuation
     G['@punctuation.delimiter'] = { link = '@operator' } -- For delimiters ie: `.`
@@ -287,17 +293,29 @@ function M.get_groups()
     G['@punctuation.special'] = { link = 'Macro' } -- For special punctutation that does not fall in the catagories before.
     G['@punctuation.special.markdown'] = { fg = C.orange.base, bold = true }
     --- Literals
+    G["@string"] = { link = "String" }
     G['@string.documentation'] = { link = 'String' }
-    G['@string.regex'] = { fg = C.magenta.bright } -- For regexes.
     G['@string.escape'] = { fg = C.magenta.bright } -- For escape characters within a string.
+    G['@string.regex'] = { fg = C.magenta.bright } -- For regexes.
     --- Functions
     G['@constructor'] = { link = 'Function' } -- For constructor calls and definitions: `= { }` in Lua, and Java constructors.
     G['@parameter'] = { fg = C.fg, italic = true } -- For parameters of a function.
     G['@parameter.builtin'] = { link = 'Builtin' } -- For builtin parameters of a function, e.g. "..." or Smali's pG[1-99]
     --- Keywords
     G['@keyword'] = { link = 'Keyword' } -- For keywords that don't fall in previous categories.
+    G["@keyword.conditional"] = { link = "Conditional" }
     G['@keyword.coroutine'] = { link = 'Macro' } -- For keywords related to coroutines.
+    G["@keyword.debug"] = { link = "Debug" }
+    G["@keyword.directive"] = { link = "PreProc" }
+    G["@keyword.directive.define"] = { link = "Define" }
+    G["@keyword.exception"] = { link = "Exception" }
+    G['@keyword.export'] = { link = 'Keyword' }
     G['@keyword.function'] = { link = 'Keyword' } -- For keywords used to define a fuction.
+    G["@keyword.import"] = { link = "Include" }
+    G['@keyword.operator'] = { link = 'Keyword' }
+    G["@keyword.repeat"] = { link = "Repeat" }
+    G['@keyword.return'] = { link = 'Keyword' }
+    G["@keyword.storage"] = { link = "StorageClass" }
     G['@label'] = { link = 'Keyword' } -- For labels: `label:` in C and `:label:` in Lua.
     --- Types
     G['@type.builtin'] = { link = 'Type' }
@@ -306,9 +324,18 @@ function M.get_groups()
     --- Identifiers
     G['@variable'] = { link = 'Variable' } -- Any variable name that does not have another highlight.
     G['@variable.builtin'] = { link = 'Builtin' } -- Variable names that are defined by the languages, like `this` or `self`.
+    G['@variable.member'] = { link = 'Field' }
     --- Text
      G['@spell'] = { link = 'Comment' }
     -- G["@text.literal.markdown"] = { }
+    G['@text'] = { link = 'Normal' } -- For strings considered text in a markup language.
+    G['@text.strong'] = { bold = true }
+    G['@text.emphasis'] = { italic = true } -- For text to be represented with emphasis.
+    G['@text.underline'] = { underline = true } -- For text to be represented with an underline.
+    G['@text.strike'] = { strikethrough = true } -- For strikethrough text.
+    G['@text.title'] = { link = 'Title' } -- Text that is part of a title.
+    G['@text.uri'] = { underline = true } -- Any URI like a link or email.
+    G['@text.literal'] = { link = 'String' }
     G['@text.literal.markdown_inline'] = { bg = C.black2, fg = C.fg }
     G['@text.reference'] = { link = 'Link' }
     G['@text.todo.unchecked'] = { fg = C.blue1 } -- For brackets and parens.
@@ -317,6 +344,29 @@ function M.get_groups()
     G['@text.danger'] = { fg = C.error }
     G['@text.diff.add'] = { link = 'DiffAdd' }
     G['@text.diff.delete'] = { link = 'DiffDelete' }
+    G['@text.todo'] = { link = 'Todo' }
+    G['@text.note'] = { link = 'Note' }
+    --- Markup
+    G["@markup"] = { link = "@none" }
+    G["@markup.emphasis"] = { italic = true }
+    G["@markup.environment"] = { link = "Macro" }
+    G["@markup.environment.name"] = { link = "Type" }
+    G["@markup.heading"] = { link = "Title" }
+    G["@markup.italic"] = { italic = true }
+    G['@markup.list'] = { link = '@operator' }
+    G["@markup.list.checked"] = { link = 'Field' }
+    G['@markup.list.markdown'] = { fg = C.yellow.base, bold = true }
+    G["@markup.list.unchecked"] = { fg = C.fg }
+    G['@markup.link'] = { fg = C.cyan.base }
+    G["@markup.link.label"] = { link = "SpecialChar" }
+    G["@markup.link.label.symbol"] = { link = "Identifier" }
+    G["@markup.link.url"] = { link = "Underlined" }
+    G["@markup.math"] = { link = "Special" }
+    G["@markup.raw"] = { link = "String" }
+    G['@markup.raw.markdown_inline'] = { bg = C.black2, fg = C.fg }
+    G["@markup.strong"] = { bold = true }
+    G["@markup.strikethrough"] = { strikethrough = true }
+    G["@markup.underline"] = { underline = true }
     -- TSX
     G['@tag.tsx'] = { fg = C.blue1 }
     G['@constructor.tsx'] = { fg = C.blue1 }
@@ -339,7 +389,7 @@ function M.get_groups()
     G['@lsp.type.selfKeyword'] = { link = 'Builtin' }
     G['@lsp.type.string.rust'] = { link = 'String' }
     G['@lsp.type.typeAlias'] = { link = 'Type' }
-    G['@lsp.type.unresolvedReference'] = {}
+    G['@lsp.type.unresolvedReference'] = { undercurl = true, sp = C.error }
     G['@lsp.type.variable'] = {} -- use treesitter styles for regular variables
     G['@lsp.typemod.class.defaultLibrary'] = { link = 'Type' }
     G['@lsp.typemod.enum.defaultLibrary'] = { link = 'Type' }
@@ -355,34 +405,29 @@ function M.get_groups()
     G['@lsp.typemod.variable.injected'] = { link = 'Variable' }
     G['@lsp.typemod.variable.globalScope'] = { link = 'Macro' }
     -- Things that seems to be missing?
-    G['@text.todo'] = { link = 'Todo' }
-    G['@text.note'] = { link = 'Note' }
+    G["@annotation"] = { link = "PreProc" }
+    G["@diff.plus"] = { link = "DiffAdd" }
+    G["@diff.minus"] = { link = "DiffDelete" }
+    G["@diff.delta"] = { link = "DiffChange" }
+    G["@character"] = { link = "Character" }
+    G["@character.special"] = { link = "SpecialChar" }
     G['@string.special'] = { fg = C.yellow.base } -- For escape characters within a string.
     G['@tag'] = { fg = C.blue1 } -- Tags like html tag names.
     G['@tag.delimiter'] = { fg = C.fg } -- Tag delimiter like `<` `>` `/`
     G['@tag.attribute'] = { fg = C.yellow.base } -- Tag attribute like `id` `class`
-    G['@text'] = { link = 'Normal' } -- For strings considered text in a markup language.
-    G['@text.strong'] = { bold = true }
-    G['@text.emphasis'] = { italic = true } -- For text to be represented with emphasis.
-    G['@text.underline'] = { underline = true } -- For text to be represented with an underline.
-    G['@text.strike'] = { strikethrough = true } -- For strikethrough text.
-    G['@text.title'] = { link = 'Title' } -- Text that is part of a title.
-    G['@text.uri'] = { underline = true } -- Any URI like a link or email.
-    G['@text.literal'] = { link = 'String' }
     G['@constant'] = { link = 'Constant' }
     G['@number'] = { link = 'Constant' }
     G['@float'] = { link = 'Constant' }
     G['@boolean'] = { link = 'Constant' }
     G['@constant.macro'] = { link = 'Constant' }
     G['@constant.builtin'] = { link = 'Constant' }
-    G['@keyword.return'] = { link = 'Keyword' }
-    G['@keyword.export'] = { link = 'Keyword' }
     G['@repeat'] = { link = 'Keyword' }
     G['@conditional'] = { link = 'Keyword' }
     G['@class'] = { link = 'Keyword' }
-    G['@keyword.operator'] = { link = 'Keyword' }
     G['@include'] = { link = 'Include' }
     G['@macro'] = { link = 'Macro' }
+    G["@module"] = { fg = C.yellow.base }
+    G['@module.builtin'] = { link = 'Builtin' }
     G['@preproc'] = { link = 'Macro' }
     G['@attribute'] = { link = 'Macro' }
     G['@function.macro'] = { link = 'Macro' }

--- a/lua/nordic/groups/integrations.lua
+++ b/lua/nordic/groups/integrations.lua
@@ -288,7 +288,7 @@ function M.get_groups()
     G["@comment.todo"] = { fg = C.todo }
     G['@operator'] = { fg = C.fg } -- For any operator: `+`, but also `->` and `*` in C.
     --- Punctuation
-    G['@punctuation.delimiter'] = { link = '@operator' } -- For delimiters ie: `.`
+    G['@punctuation.delimiter'] = { link = 'Delimiter' } -- For delimiters ie: `.`
     G['@punctuation.bracket'] = { link = '@operator' } -- For brackets and parens.
     G['@punctuation.special'] = { link = 'Macro' } -- For special punctutation that does not fall in the catagories before.
     G['@punctuation.special.markdown'] = { fg = C.orange.base, bold = true }

--- a/lua/nordic/groups/native.lua
+++ b/lua/nordic/groups/native.lua
@@ -49,7 +49,7 @@ function M.get_groups()
     G.Special = { fg = C.blue1 } -- (preferred) any special symbol
     -- SpecialChar   = { } --  special character in a constant
     -- Tag           = { } --    you can use CTRL-] on this
-    -- Delimiter     = { } --  character that needs attention
+    G.Delimiter = { italic = true, fg = C.gray5} --  character that needs attention
     -- SpecialComment= { } -- special things inside a comment
     -- Debug         = { } --    debugging statements
     G.Underlined = { underline = true } -- (preferred) text that stands out, HTML links


### PR DESCRIPTION
I have ported over most changes from #110 prior to the restructuring. Some were dropped because I found that they were redundant.

The rationale for this PR is because I found that this theme does not have proper support for Neorg (and most other) markup files. I've selected formatting for highlight groups based on how Catppuccin and Tokyonight did it, though I've tried to keep it true to Nordic's flavour.

Here is a side by side comparison of the result:
![image](https://github.com/AlexvZyl/nordic.nvim/assets/24962525/46e420d3-1ff5-4bcb-9c56-9e8f481d5526)