### PR TITLE
feat(colors): make on_palette stateless;

### DIFF
--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -7,9 +7,9 @@ local function build_palette()
     -- Make a new palette.
     -- Copy the original palette this overrides C.
     C = vim.deepcopy(P)
-    -- Because of the override we need to re-add the build_palette.
+    -- Because of the override we need to re-add the build_palette to the C table.
     C.build_palette = build_palette
-    -- That is also why it is not attached to C.
+    -- If we had attached build_palette to C we would lost it after the override.
 
     local options = require('nordic.config').options
 

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -4,9 +4,12 @@ local P = require 'nordic.colors.nordic'
 local C = {}
 
 local function build_palette()
-    -- make a new palette
+    -- Make a new palette.
+    -- Copy the original palette this overrides C.
     C = vim.deepcopy(P)
+    -- Because of the override we need to re-add the build_palette.
     C.build_palette = build_palette
+    -- That is also why it is not attached to C.
 
     local options = require('nordic.config').options
 
@@ -102,5 +105,6 @@ end
 
 -- build the first palette
 build_palette()
+-- after this we can call it with C.build_palette()
 
 return C

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -1,7 +1,13 @@
 local U = require 'nordic.utils'
-local C = require 'nordic.colors.nordic'
+local P = require 'nordic.colors.nordic'
 
-function C.extend_palette()
+local C = {}
+
+local function build_palette()
+    -- make a new palette
+    C = vim.deepcopy(P)
+    C.build_palette = build_palette
+
     local options = require('nordic.config').options
 
     -- `white0` is used as the default fg, and has a blue tint.
@@ -94,8 +100,7 @@ function C.extend_palette()
     C.comment = C.gray4
 end
 
--- Sometimes the palette is required before the theme has been loaded,
--- so we need to extend the palette in those cases.
-C.extend_palette()
+-- build the first palette
+build_palette()
 
 return C

--- a/lua/nordic/init.lua
+++ b/lua/nordic/init.lua
@@ -14,7 +14,7 @@ function M.load(opts)
     end
 
     -- Setup colors
-    require('nordic.colors').extend_palette()
+    require('nordic.colors').build_palette()
 
     -- Apply theme
     local G = require 'nordic.groups'


### PR DESCRIPTION
Currently on_palette can irreversibly change the palette requiring a full restart to fix.

This also means that implementations of on_palette have to account for changes made in previous calls.

This commit fixes that by rebuilding the palette with each setup.

As such extend_palette has been renamed to build_palette.