### PR TITLE
fix(build_palette): fix broken reload in stateless palette;

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Nordic will use the default values, unless `setup` is called. Below is the defau
 ```lua
 require 'nordic' .setup {
     -- This callback can be used to override the colors used in the palette.
-    on_palette = function(palette) return palette end,
+    on_palette = function(palette) end,
     -- Enable bold keywords.
     bold_keywords = false,
     -- Enable italic comments.

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -4,14 +4,8 @@ local P = require 'nordic.colors.nordic'
 local C = {}
 
 function C.build_palette()
-    -- clear all values except build_palette
-    for k, _ in pairs(C) do
-        if k ~= "build_palette" then
-            C[k] = nil
-        end
-    end
-    -- copy all values from the base palette
-    U.merge_inplace(C, vim.deepcopy(P))
+    -- override all values from the base palette
+    U.merge_inplace(C, P)
 
     local options = require('nordic.config').options
 

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -11,9 +11,7 @@ function C.build_palette()
         end
     end
     -- copy all values from the base palette
-    for k, v in pairs(vim.deepcopy(P)) do
-        C[k] = v
-    end
+    U.merge_inplace(C, vim.deepcopy(P))
 
     local options = require('nordic.config').options
 

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -20,7 +20,7 @@ function C.build_palette()
     C.white0 = (options.reduced_blue and C.white0_reduce_blue) or C.white0_normal
 
     -- Modify the palette before generating colors.
-    C = options.on_palette(C)
+    options.on_palette(C)
 
     -- Add these for international convenience :)
     C.grey0 = C.gray0

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -3,13 +3,17 @@ local P = require 'nordic.colors.nordic'
 
 local C = {}
 
-local function build_palette()
-    -- Make a new palette.
-    -- Copy the original palette this overrides C.
-    C = vim.deepcopy(P)
-    -- Because of the override we need to re-add the build_palette to the C table.
-    C.build_palette = build_palette
-    -- If we had attached build_palette to C we would lost it after the override.
+function C.build_palette()
+    -- clear all values except build_palette
+    for k, _ in pairs(C) do
+        if k ~= "build_palette" then
+            C[k] = nil
+        end
+    end
+    -- copy all values from the base palette
+    for k, v in pairs(vim.deepcopy(P)) do
+        C[k] = v
+    end
 
     local options = require('nordic.config').options
 
@@ -102,7 +106,6 @@ local function build_palette()
 end
 
 -- build the first palette
-build_palette()
--- after this we can call it with C.build_palette()
+C.build_palette()
 
 return C

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -103,7 +103,4 @@ function C.build_palette()
     C.comment = C.gray4
 end
 
--- build the first palette
-C.build_palette()
-
 return C

--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -2,9 +2,7 @@ local M = {}
 
 local defaults = {
     -- This callback can be used to override the colors used in the palette.
-    on_palette = function(palette)
-        return palette
-    end,
+    on_palette = function(palette) end,
     -- Enable bold keywords.
     bold_keywords = false,
     -- Enable italic comments.
@@ -18,9 +16,9 @@ local defaults = {
     },
     -- Enable brighter float border.
     bright_border = false,
-    -- Adjusts some colors to make the theme a bit nicer (imo).
+    -- Reduce the overall amount of blue in the theme (diverges from base Nord).
     reduced_blue = true,
-    -- Swop the dark background with the normal one.
+    -- Swap the dark background with the normal one.
     swap_backgrounds = false,
     -- Override the styling of any highlight group.
     override = {},
@@ -58,7 +56,7 @@ M.options = defaults
 -- called automatically by load
 function M.setup(options)
     -- backwards compatibility
-    options = require 'nordic.compatibility'(options)
+    options = require 'nordic.compatibility' (options)
 
     -- set defaults
     M.options = vim.tbl_deep_extend('force', M.options or defaults, options or {})

--- a/lua/nordic/utils.lua
+++ b/lua/nordic/utils.lua
@@ -29,9 +29,16 @@ function M.merge(table1, table2)
     return vim.tbl_deep_extend('force', table1, table2)
 end
 
-function M.merge_inplace(t1, t2)
-    for k, v in pairs(t2) do
-        t1[k] = v
+function M.merge_inplace(table1, table2)
+    for k, v in pairs(table2) do
+        if type(v) == "table" then
+            if type(table1[k]) ~= "table" then
+                table1[k] = {}
+            end
+            M.merge_inplace(table1[k], v)
+        else
+            table1[k] = v
+        end
     end
 end
 

--- a/lua/nordic/utils.lua
+++ b/lua/nordic/utils.lua
@@ -29,6 +29,12 @@ function M.merge(table1, table2)
     return vim.tbl_deep_extend('force', table1, table2)
 end
 
+function M.merge_inplace(t1, t2)
+    for k, v in pairs(t2) do
+        t1[k] = v
+    end
+end
+
 function M.hex_to_rgb(str)
     str = string.lower(str)
     return tonumber(str:sub(2, 3), 16), tonumber(str:sub(4, 5), 16), tonumber(str:sub(6, 7), 16)


### PR DESCRIPTION
So somehow I missed that `C = vim.deepcopy(P)` (#125 ) would break the upvalue reference, then somehow I did not notice that while testing (If I did any testing, that is, I don't really remember...).

Anyway, this should fix that, and it's more readable now.

Super-Duper, sorry about this (´°ω°`)