### PR TITLE
 Feat: Improve pmenu & bg_visual colors for better visibility

### DIFF
--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -35,9 +35,7 @@ local function build_palette()
     C.bg = (options.transparent.bg and C.none) or ((options.swap_backgrounds and C.black1) or C.gray0)
     C.bg_dark = (options.transparent.bg and C.none) or C.black0
     C.bg_sidebar = (options.transparent.bg and C.none) or C.bg
-    C.bg_popup = (options.transparent.float and C.none) or C.bg
     C.bg_statusline = C.black0
-    C.bg_selected = U.blend(C.gray2, C.black0, 0.4)
     C.bg_fold = C.gray2
 
     -- Cursorline Background
@@ -62,17 +60,19 @@ local function build_palette()
     C.fg_fold = C.fg
     C.fg_selected = C.fg_bright
 
-    -- Popups
-    C.bg_popup = C.bg
-    C.fg_popup = C.fg
-    C.bg_popup_border = C.bg
-    C.fg_popup_border = C.border_fg
 
     -- Floating windows
     C.bg_float = (options.transparent.float and C.none) or ((options.swap_backgrounds and C.gray0) or C.black1)
     C.fg_float = C.fg
     C.bg_float_border = C.bg_float
     C.fg_float_border = C.border_fg
+
+    -- Popups
+    C.bg_popup = C.bg_float
+    C.bg_selected = C.gray2
+    C.fg_popup = C.fg
+    C.bg_popup_border = C.bg
+    C.fg_popup_border = C.border_fg
 
     -- Diffs
     local diff_blend = 0.2

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -40,7 +40,7 @@ local function build_palette()
 
     -- Cursorline Background
     if options.cursorline.theme == 'light' then
-        options.cursorline.bg = C.gray1
+        options.cursorline.bg = C.gray2
     else
         options.cursorline.bg = C.black0
     end


### PR DESCRIPTION
I changed to `bg_popup = bg_float` and `bg_selected = gray2`:
![image](https://github.com/AlexvZyl/nordic.nvim/assets/155409640/618cf1a1-e150-4eeb-9944-9700ace8c664)
& with `swap_background = true`:
![image](https://github.com/AlexvZyl/nordic.nvim/assets/155409640/47399f65-63e8-4e9e-99c4-23df1277676e)

The other thing I think looks better is changing `bg_visual = gray2` here it is with blend set to `0.5`:
- old:
![image](https://github.com/AlexvZyl/nordic.nvim/assets/155409640/735449c4-94d2-4de3-b554-77ecd8b28419)
- new:
![image](https://github.com/AlexvZyl/nordic.nvim/assets/155409640/2fff773d-5726-4ded-9f58-60589e948a2e)


Closes #135 
