### PR TITLE
Feat: Improve changing of highlights with `on_highlight`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Nordic will use the default values, unless `setup` is called. Below is the defau
 require 'nordic' .setup {
     -- This callback can be used to override the colors used in the palette.
     on_palette = function(palette) end,
+    -- This callback can be used to override highlights before they are applied.
+    on_highlight = function(highlights, palette) end,
     -- Enable bold keywords.
     bold_keywords = false,
     -- Enable italic comments.
@@ -103,8 +105,6 @@ require 'nordic' .setup {
     reduced_blue = true,
     -- Swap the dark background with the normal one.
     swap_backgrounds = false,
-    -- Override the styling of any highlight group.
-    override = {},
     -- Cursorline options.  Also includes visual/selection.
     cursorline = {
         -- Bold font in cursorline.
@@ -135,13 +135,16 @@ require 'nordic' .setup {
 }
 ```
 
-An example of overriding the `TelescopePromptTitle` colors:
+**Examples:**
 
+<details>
+    <summary><b><code>on_highlight</code></b></summary>
+
+An example of overriding the `TelescopePromptTitle` colors:
 ```lua
-local palette = require 'nordic.colors'
-require 'nordic' .setup {
-    override = {
-        TelescopePromptTitle = {
+require('nordic').setup {
+    on_highlight = function(highlights, palette)
+        highlights.TelescopePromptTitle = {
             fg = palette.red.bright,
             bg = palette.green.base,
             italic = true,
@@ -149,9 +152,23 @@ require 'nordic' .setup {
             sp = palette.yellow.dim,
             undercurl = false
         }
-    }
+    end,
 }
 ```
+
+And an example of disabling all italics:
+```lua
+require('nordic').setup {
+    on_highlight = function(highlights, _palette)
+        for _, highlight in pairs(highlights) do
+            highlight.italic = false
+        end
+    end
+}
+```
+
+</details>
+
 
 # 🗒️ Supported Plugins and Platforms
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,6 @@ require 'lualine' .setup {
 }
 ```
 
-To get the palette in lua:
-
-```lua
-local palette = require 'nordic.colors'
-```
-
 # ⚙️ Configuration
 
 Nordic will use the default values, unless `setup` is called. Below is the default configuration.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ local palette = require 'nordic.colors'
 Nordic will use the default values, unless `setup` is called. Below is the default configuration.
 
 ```lua
-require 'nordic' .setup {
+require('nordic').setup({
     -- This callback can be used to override the colors used in the palette.
     on_palette = function(palette) end,
     -- This callback can be used to override highlights before they are applied.
@@ -132,17 +132,33 @@ require 'nordic' .setup {
         -- Enables dark background for treesitter-context window
         dark_background = true,
     }
-}
+})
 ```
 
 **Examples:**
+
+<details>
+    <summary><b><code>on_palette</code></b></summary>
+
+An example of overriding colors in the base palette:
+```lua
+require('nordic').setup({
+    on_palette = function(palette)
+        palette.black0 = "#BF616A"
+        palette.green.base = palette.cyan.base
+    end,
+})
+```
+
+</details>
+
 
 <details>
     <summary><b><code>on_highlight</code></b></summary>
 
 An example of overriding the `TelescopePromptTitle` colors:
 ```lua
-require('nordic').setup {
+require('nordic').setup({
     on_highlight = function(highlights, palette)
         highlights.TelescopePromptTitle = {
             fg = palette.red.bright,
@@ -153,18 +169,18 @@ require('nordic').setup {
             undercurl = false
         }
     end,
-}
+})
 ```
 
 And an example of disabling all italics:
 ```lua
-require('nordic').setup {
+require('nordic').setup({
     on_highlight = function(highlights, _palette)
         for _, highlight in pairs(highlights) do
             highlight.italic = false
         end
     end
-}
+})
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ require('nordic').setup({
 
 <details>
     <summary><b><code>on_palette</code></b></summary>
+&nbsp;
 
 An example of overriding colors in the base palette:
 ```lua
@@ -155,6 +156,7 @@ require('nordic').setup({
 
 <details>
     <summary><b><code>on_highlight</code></b></summary>
+&nbsp;
 
 An example of overriding the `TelescopePromptTitle` colors:
 ```lua

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -96,4 +96,7 @@ function C.build_palette()
     C.comment = C.gray4
 end
 
+-- build the first palette
+C.build_palette()
+
 return C

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -4,7 +4,7 @@ local P = require 'nordic.colors.nordic'
 local C = {}
 
 function C.build_palette()
-    -- override all values from the base palette
+    -- Override all values from the base palette.
     U.merge_inplace(C, P)
 
     local options = require('nordic.config').options
@@ -96,7 +96,7 @@ function C.build_palette()
     C.comment = C.gray4
 end
 
--- build the first palette
+-- Build the first palette.
 C.build_palette()
 
 return C

--- a/lua/nordic/compatibility.lua
+++ b/lua/nordic/compatibility.lua
@@ -1,5 +1,8 @@
+local U = require("nordic.utils");
+
 local function compatability(options)
     -- All backwards compatibility
+    -- While an option is deprecated it should still work but be overridden by its replacement
 
     -- Log level
     local level = vim.log.levels.WARN
@@ -15,10 +18,30 @@ local function compatability(options)
             level,
             message_options
         )
+
         options.transparent = {
             bg = options.transparent_bg,
             float = options.transparent_bg,
         }
+    end
+
+    -- override
+    if options.override ~= nil then
+        vim.notify_once(
+            'Nordic.nvim: config.override is deprecated, use config.on_highlight instead',
+            level,
+            message_options
+        )
+
+        local users_on_highlight = options.on_highlight;
+        -- Create a new on_highlight that will apply `override` and then the users `on_highlight`
+        options.on_highlight = function(highlights, palette)
+            U.merge_inplace(highlights, options.override)
+            -- This nil check is required because we have not been given default values yet
+            if users_on_highlight ~= nil then
+                users_on_highlight(highlights, palette)
+            end
+        end
     end
 
     return options

--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -3,6 +3,8 @@ local M = {}
 local defaults = {
     -- This callback can be used to override the colors used in the palette.
     on_palette = function(palette) end,
+    -- This callback can be used to override highlights before they are applied.
+    on_highlight = function(highlights, palette) end,
     -- Enable bold keywords.
     bold_keywords = false,
     -- Enable italic comments.
@@ -20,8 +22,6 @@ local defaults = {
     reduced_blue = true,
     -- Swap the dark background with the normal one.
     swap_backgrounds = false,
-    -- Override the styling of any highlight group.
-    override = {},
     -- Cursorline options.  Also includes visual/selection.
     cursorline = {
         -- Bold font in cursorline.

--- a/lua/nordic/groups/init.lua
+++ b/lua/nordic/groups/init.lua
@@ -3,10 +3,16 @@ local merge = require('nordic.utils').merge
 local M = {}
 
 function M.get_groups()
-    local groups =
-        merge(require('nordic.groups.native').get_groups(), require('nordic.groups.integrations').get_groups())
+    local native = require('nordic.groups.native').get_groups()
+    local integrations = require('nordic.groups.integrations').get_groups()
+    local groups = merge(native, integrations)
 
-    return merge(groups, require('nordic.config').options.override)
+    -- Apply on_highlight
+    local palette = require('nordic.colors')
+    local options = require("nordic.config").options
+    options.on_highlight(groups, palette)
+
+    return groups
 end
 
 function M.set_term_colors()

--- a/lua/nordic/tests/options.lua
+++ b/lua/nordic/tests/options.lua
@@ -20,6 +20,18 @@ config.on_palette = function(palette)
     return palette
 end
 
+config.on_highlight = function(highlights, palette)
+    highlights.TelescopePromptTitle = {
+        fg = palette.red.bright,
+        bg = palette.green.base,
+        italic = true,
+        underline = true,
+        sp = palette.yellow.dim,
+        undercurl = false
+    }
+    return highlights
+end
+
 -- Flip all fields
 config.bold_keywords = not config.bold_keywords
 config.italic_comments = not config.italic_comments

--- a/lua/nordic/tests/options.lua
+++ b/lua/nordic/tests/options.lua
@@ -17,7 +17,6 @@ load(config)
 
 config.on_palette = function(palette)
     palette.black0 = '#000000'
-    return palette
 end
 
 config.on_highlight = function(highlights, palette)
@@ -29,7 +28,6 @@ config.on_highlight = function(highlights, palette)
         sp = palette.yellow.dim,
         undercurl = false
     }
-    return highlights
 end
 
 -- Flip all fields


### PR DESCRIPTION
`override` configuration option replaced with `on_highlight` similar to tokyonight's [on_highlights](https://github.com/folke/tokyonight.nvim/blob/fbe3a27378fdd51a8ddd04f57012455436916a62/lua/tokyonight/theme.lua#L873):
```lua
require 'nordic' .setup {
    -- This callback can be used to override highlights before they are applied.
    on_highlight = function(highlights, palette)
        highlights.TelescopePromptTitle = {
            fg = palette.red.bright,
            bg = palette.green.base,
            italic = true,
            underline = true,
            sp = palette.yellow.dim,
            undercurl = false
        }
    end
}
```