### PR TITLE
Feat: Add `after_palette` to override extended palette values

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ Nordic will use the default values, unless `setup` is called. Below is the defau
 
 ```lua
 require('nordic').setup({
-    -- This callback can be used to override the colors used in the palette.
+    -- This callback can be used to override the colors used in the base palette.
     on_palette = function(palette) end,
+    -- This callback can be used to override the colors used in the extended palette.
+    after_palette = function(palette) end,
     -- This callback can be used to override highlights before they are applied.
     on_highlight = function(highlights, palette) end,
     -- Enable bold keywords.
@@ -149,6 +151,22 @@ require('nordic').setup({
     on_palette = function(palette)
         palette.black0 = "#BF616A"
         palette.green.base = palette.cyan.base
+    end,
+})
+```
+
+</details>
+
+
+<details>
+    <summary><b><code>after_palette</code></b></summary>
+&nbsp;
+
+An example of setting the visual selection color (for more values see [this file](https://github.com/AlexvZyl/nordic.nvim/blob/main/lua/nordic/colors/init.lua)):
+```lua
+require('nordic').setup({
+    after_palette = function(palette)
+        palette.bg_visual = require("nordic.utils").blend(palette.orange.base, palette.bg, 0.15)
     end,
 })
 ```

--- a/lua/nordic/colors/init.lua
+++ b/lua/nordic/colors/init.lua
@@ -94,6 +94,9 @@ function C.build_palette()
 
     -- Misc
     C.comment = C.gray4
+
+    -- Modify the palette after generating colors.
+    options.after_palette(C)
 end
 
 -- Build the first palette.

--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -1,8 +1,10 @@
 local M = {}
 
 local defaults = {
-    -- This callback can be used to override the colors used in the palette.
+    -- This callback can be used to override the colors used in the base palette.
     on_palette = function(palette) end,
+    -- This callback can be used to override the colors used in the extended palette.
+    after_palette = function(palette) end,
     -- This callback can be used to override highlights before they are applied.
     on_highlight = function(highlights, palette) end,
     -- Enable bold keywords.

--- a/lua/nordic/tests/options.lua
+++ b/lua/nordic/tests/options.lua
@@ -19,6 +19,11 @@ config.on_palette = function(palette)
     palette.black0 = '#000000'
 end
 
+config.after_palette = function(palette)
+    palette.bg_visual = require("nordic.utils").blend(palette.orange.base, palette.bg, 0.15)
+end
+
+
 config.on_highlight = function(highlights, palette)
     highlights.TelescopePromptTitle = {
         fg = palette.red.bright,


### PR DESCRIPTION
Adds the third callback discussed in #124 

An example of setting the visual selection color (for more values see [this file](https://github.com/AlexvZyl/nordic.nvim/blob/main/lua/nordic/colors/init.lua)):
```lua
require('nordic').setup({
    after_palette = function(palette)
        palette.bg_visual = require("nordic.utils").blend(palette.orange.base, palette.bg, 0.15)
    end,
})
```
