### PR TITLE
added support for rainbow-delimeters.nvim

### DIFF
--- a/lua/nordic/groups/integrations.lua
+++ b/lua/nordic/groups/integrations.lua
@@ -523,6 +523,13 @@ function M.get_groups()
     G.WhichKeySeperator = {}
     G.WhichKeyValue = {}
 
+    -- Rainbow delimiters
+    G.RainbowDelimiterOrange = { fg = C.orange.base }
+    G.RainbowDelimiterYellow = { fg = C.yellow.bright }
+    G.RainbowDelimiterBlue = { fg = C.blue2 }
+    G.RainbowDelimiterRed = { fg = C.red.bright }
+    G.RainbowDelimiterGreen = { fg = C.green.bright}
+
     return G
 end
 


### PR DESCRIPTION
Added highlighting for the rainbow-delimiters plugin (https://github.com/HiPhish/rainbow-delimiters.nvim)

Just added the highlighting to the integrations page. Used the colors I thought looked best in the context of the colorscheme