### PR TITLE
Fix: Weird neo-tree highlights;

### DIFF
--- a/lua/nordic/groups/integrations.lua
+++ b/lua/nordic/groups/integrations.lua
@@ -120,7 +120,6 @@ function M.get_groups()
     G.NeoTreeCursorLine = { link = 'NvimTreeCursorLine' }
     G.NeoTreeDirectoryIcon = { link = 'NvimTreeFolderIcon' }
     G.NeoTreeRootName = { link = 'NvimTreeRootFolder' }
-    G.NeoTreeFileName = { link = 'NvimTreeNormal' }
     G.NeoTreeFileIcon = { fg = C.blue2 }
     G.NeoTreeFileNameOpened = { fg = C.fg }
     G.NeoTreeIndentMarker = { link = 'NvimTreeIndentMarker' }


### PR DESCRIPTION
Fixes: #151 

**NeoTreeFileName** was linked to **NvimTreeNormal** which has a bg specified that bg was overwriting the selection highlighting:

![image](https://github.com/user-attachments/assets/d0df034b-23da-4acd-88bc-af989ea3f6ef)
![image](https://github.com/user-attachments/assets/45790c63-ce44-44fe-b66c-e9ece90867c0)

There are two ways this is can be fix:

1. `G.NeoTreeFileName = { fg = C.fg }`
2. Just remove the whole thing... It defaults to the normal foreground so I went with this. (Also that's what every other theme I looked at did).