### PR TITLE
ci(tests): fix path to neovim appimage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id:   branch-name
         uses: tj-actions/branch-names@v6
 
@@ -23,7 +23,7 @@ jobs:
         shell: bash
         run:  |
               mkdir -p /tmp/nvim
-              wget -q https://github.com/neovim/neovim/releases/download/nightly/nvim.appimage -O /tmp/nvim/nvim.appimage
+              wget -q https://github.com/neovim/neovim/releases/download/v0.10.4/nvim-linux-x86_64.appimage -O /tmp/nvim/nvim.appimage
               cd /tmp/nvim
               chmod a+x ./nvim.appimage
               ./nvim.appimage --appimage-extract


### PR DESCRIPTION
Upstream changed the path to the neovim appimage and since we no longer need the nightly version of neovim, we can use the latest release.

Also update checkout action to v4.