### PR TITLE
Integration with visual-whitespace.nvim

### DIFF
--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -61,6 +61,7 @@ local defaults = {
         treesitter_context = true,
         trouble = true,
         vimtex = true,
+        visual_whitespace = true,
         which_key = true,
     },
     noice = {

--- a/lua/nordic/groups/integrations/visual_whitespace.lua
+++ b/lua/nordic/groups/integrations/visual_whitespace.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+function M.get()
+    local C = require('nordic.colors')
+
+    local G = {}
+
+    G.VisualNonText = { fg = C.comment, bg = C.bg_visual }
+
+    return G
+end
+
+return M


### PR DESCRIPTION
Provides integration with the [visual-whitespace.nvim plugin](https://github.com/mcauley-penney/visual-whitespace.nvim). It's a plugin to show whitespace in visual mode, similar to how it works with trailing whitespace when setting [`listchars`](https://neovim.io/doc/user/options.html#'listchars').

Example of how it looks:
![image](https://github.com/user-attachments/assets/625794f7-4b74-4070-a10e-d4b04eb21b31)

