### PR TITLE
Feat(integrations): Snacks picker integrations

### DIFF
--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -56,6 +56,7 @@ local defaults = {
         nvim_dap = true,
         nvim_tree = true,
         rainbow_delimiters = true,
+        snacks_picker = true,
         telescope = true,
         treesitter = true,
         treesitter_context = true,
@@ -67,6 +68,12 @@ local defaults = {
     noice = {
         -- Available styles: `classic`, `flat`.
         style = 'classic',
+    },
+    snacks = {
+        picker = {
+            -- Available styles: `classic`, `flat`
+            style = 'flat',
+        },
     },
     telescope = {
         -- Available styles: `classic`, `flat`.

--- a/lua/nordic/groups/integrations/snacks_picker.lua
+++ b/lua/nordic/groups/integrations/snacks_picker.lua
@@ -1,0 +1,39 @@
+local M = {}
+
+function M.get()
+    local C = require('nordic.colors')
+    local O = require('nordic.config').options
+
+    local G = {}
+
+    -- Classic.
+    G.SnacksPicker = { bg = C.bg }
+    G.SnacksPickerInput = { bg = C.bg }
+    G.SnacksPickerPreview = { bg = C.bg }
+    G.SnacksPickerCursorLine = { bg = C.gray2 }
+    G.SnacksPickerTitle = { fg = C.white0, bg = C.bg, bold = true }
+    G.SnacksPickerBorder = { fg = C.white0, bg = C.bg }
+    G.SnacksPickerMatch = { bg = C.gray1, fg = C.orange.bright }
+
+    -- -- Flat.
+    if O.snacks.picker.style == 'flat' then
+        G.SnacksPicker = { bg = C.bg_float }
+        G.SnacksPickerInput = { bg = C.black0 }
+        G.SnacksPickerPreview = { bg = C.bg_float }
+
+        G.SnacksPickerTitle = { bg = C.orange.base, fg = C.black0, bold = true }
+        G.SnacksPreviewTitle = { bg = C.blue2, fg = C.black0, bold = true }
+
+        G.SnacksPickerBorder = { fg = C.black0, bg = C.black0 }
+        G.SnacksPickerInputBorder = { fg = C.black0, bg = C.black0 }
+        G.SnacksPickerPreviewBorder = { bg = C.black0, fg = C.black0 }
+
+        G.SnacksPickerCursorLine = { bg = C.gray3, bold = true }
+        G.SnacksPickerListCursorLine = { link = 'SnacksPickerCursorLine' }
+        G.SnacksPickerPreviewCursorLine = { link = 'SnacksPickerCursorLine' }
+    end
+
+    return G
+end
+
+return M


### PR DESCRIPTION
This is almost a direct copy of telescopes integration. I tried to map the highlight groups as closely as I could.

I added `snacks_picker` to the integrations table for enabling and disabling.
I also added a `snacks.picker` table to the root of the configuration as well so in the future it shouldn't result in breaking changes to add other snacks integrations.

Attached as screenshots of both the `classic` and `flat` styles
### Classic
![image](https://github.com/user-attachments/assets/c959d3bc-ba62-4a60-9fab-1d2f8e5dd1ed)

### Flat
![image](https://github.com/user-attachments/assets/dd36a340-b6f4-4efb-9de1-ba1cdc9008fe)