### PR TITLE
feat(integrations): shared Picker groups for Telescope and Snacks

### DIFF
--- a/lua/nordic/compatibility.lua
+++ b/lua/nordic/compatibility.lua
@@ -42,6 +42,16 @@ local function compatability(options)
         end
     end
 
+    -- telescope.style -> picker.style
+    if options.telescope ~= nil and options.telescope.style ~= nil then
+        if options.picker == nil then
+            options.picker = {}
+        end
+        if options.picker.style == nil then
+            options.picker.style = options.telescope.style
+        end
+    end
+
     return options
 end
 

--- a/lua/nordic/config.lua
+++ b/lua/nordic/config.lua
@@ -67,6 +67,7 @@ local defaults = {
         nvim_dap = true,
         nvim_tree = true,
         rainbow_delimiters = true,
+        snacks_picker = true,
         telescope = true,
         treesitter = true,
         treesitter_context = true,
@@ -78,6 +79,11 @@ local defaults = {
     noice = {
         -- Available styles: `classic`, `flat`.
         style = 'classic',
+    },
+    picker = {
+        -- Available styles: `classic`, `flat`.
+        -- Applies to both Telescope and Snacks picker.
+        style = 'flat',
     },
     telescope = {
         -- Available styles: `classic`, `flat`.

--- a/lua/nordic/groups/integrations/snacks_picker.lua
+++ b/lua/nordic/groups/integrations/snacks_picker.lua
@@ -1,0 +1,30 @@
+local M = {}
+
+function M.get()
+    local G = {}
+
+    -- Window highlight groups.
+    G.SnacksPicker = { link = 'PickerNormal' }
+    G.SnacksPickerBorder = { link = 'PickerBorder' }
+    G.SnacksPickerTitle = { link = 'PickerTitle' }
+    G.SnacksPickerList = { link = 'PickerResultsNormal' }
+    G.SnacksPickerListBorder = { link = 'PickerResultsBorder' }
+    G.SnacksPickerListTitle = { link = 'PickerResultsTitle' }
+    G.SnacksPickerInput = { link = 'PickerPromptNormal' }
+    G.SnacksPickerInputBorder = { link = 'PickerPromptBorder' }
+    G.SnacksPickerInputTitle = { link = 'PickerPromptTitle' }
+    G.SnacksPickerPreview = { link = 'PickerPreviewNormal' }
+    G.SnacksPickerPreviewBorder = { link = 'PickerPreviewBorder' }
+    G.SnacksPickerPreviewTitle = { link = 'PickerPreviewTitle' }
+
+    -- Content highlight groups.
+    G.SnacksPickerMatch = { link = 'PickerMatching' }
+    G.SnacksPickerPrompt = { link = 'PickerPromptPrefix' }
+    G.SnacksPickerSelected = { link = 'PickerMultiIcon' }
+    G.SnacksPickerCursorLine = { link = 'PickerSelection' }
+    G.SnacksPickerListCursorLine = { link = 'PickerSelection' }
+
+    return G
+end
+
+return M

--- a/lua/nordic/groups/integrations/telescope.lua
+++ b/lua/nordic/groups/integrations/telescope.lua
@@ -1,53 +1,27 @@
 local M = {}
 
 function M.get()
-    local C = require('nordic.colors')
-    local O = require('nordic.config').options
-
     local G = {}
 
-    -- Classic.
-    G.TelescopeNormal = { bg = C.bg }
-    G.TelescopePromptNormal = { bg = C.bg }
-    G.TelescopeResultsNormal = { bg = C.bg }
-    G.TelescopePreviewNormal = { bg = C.bg }
-    G.TelescopePreviewLine = { bg = C.gray2 }
-    G.TelescopeSelection = { bg = C.bg, fg = C.yellow.bright, bold = false }
-    G.TelescopeSelectionCaret = { fg = C.yellow.bright, bg = C.bg, bold = true }
-    G.TelescopePreviewTitle = { fg = C.white0, bg = C.bg, bold = true }
-    G.TelescopeResultsTitle = { fg = C.white0, bg = C.bg, bold = true }
-    G.TelescopePromptTitle = { fg = C.white0, bg = C.bg, bold = true }
-    G.TelescopeTitle = { fg = C.white0, bg = C.bg, bold = true }
-    G.TelescopeBorder = { fg = C.white0, bg = C.bg }
-    G.TelescopePromptBorder = { fg = C.white0, bg = C.bg }
-    G.TelescopeResultsBorder = { fg = C.white0, bg = C.bg }
-    G.TelescopePreviewBorder = { fg = C.white0, bg = C.bg }
-    G.TelescopeMatching = { fg = C.orange.base, bold = true }
-    G.TelescopePromptPrefix = { bg = C.bg, fg = C.orange.bright }
-    G.TelescopeMultiIcon = { fg = C.yellow.bright, bg = C.bg, bold = true }
-    G.TelescopeMultiSelection = { bg = C.bg }
-
-    -- Flat.
-    if O.telescope.style == 'flat' then
-        G.TelescopeNormal = { bg = C.bg_float }
-        G.TelescopePromptNormal = { bg = C.black2 }
-        G.TelescopeResultsNormal = { bg = C.bg_float }
-        G.TelescopePreviewNormal = { bg = C.bg_float }
-        G.TelescopeSelection = { bg = C.bg_visual, fg = C.yellow.bright }
-        G.TelescopeSelectionCaret = { fg = C.yellow.bright, bg = C.bg_float, bold = true }
-        G.TelescopePreviewTitle = { bg = C.blue2, fg = C.black0, bold = true }
-        G.TelescopeResultsTitle = { bg = C.orange.base, fg = C.black0, bold = true }
-        G.TelescopePromptTitle = { bg = C.orange.base, fg = C.black0, bold = true }
-        G.TelescopeTitle = { bg = C.orange.base, fg = C.black0, bold = true }
-        G.TelescopeBorder = { fg = C.black0, bg = C.black0 }
-        G.TelescopePromptBorder = { bg = C.black2, fg = C.black0 }
-        G.TelescopeResultsBorder = { bg = C.bg_float, fg = C.black0 }
-        G.TelescopePreviewBorder = { bg = C.bg_float, fg = C.black0 }
-        G.TelescopeMultiIcon = { fg = C.yellow.bright, bg = C.bg_float, bold = true }
-        G.TelescopeMultiSelection = { bg = C.bg_float }
-        G.TelescopePromptPrefix = { bg = C.black2, fg = C.orange.bright }
-        G.TelescopePreviewLine = { bg = C.gray1 }
-    end
+    G.TelescopeNormal = { link = 'PickerNormal' }
+    G.TelescopePromptNormal = { link = 'PickerPromptNormal' }
+    G.TelescopeResultsNormal = { link = 'PickerResultsNormal' }
+    G.TelescopePreviewNormal = { link = 'PickerPreviewNormal' }
+    G.TelescopePreviewLine = { link = 'PickerPreviewLine' }
+    G.TelescopeSelection = { link = 'PickerSelection' }
+    G.TelescopeSelectionCaret = { link = 'PickerSelectionCaret' }
+    G.TelescopePreviewTitle = { link = 'PickerPreviewTitle' }
+    G.TelescopeResultsTitle = { link = 'PickerResultsTitle' }
+    G.TelescopePromptTitle = { link = 'PickerPromptTitle' }
+    G.TelescopeTitle = { link = 'PickerTitle' }
+    G.TelescopeBorder = { link = 'PickerBorder' }
+    G.TelescopePromptBorder = { link = 'PickerPromptBorder' }
+    G.TelescopeResultsBorder = { link = 'PickerResultsBorder' }
+    G.TelescopePreviewBorder = { link = 'PickerPreviewBorder' }
+    G.TelescopeMatching = { link = 'PickerMatching' }
+    G.TelescopePromptPrefix = { link = 'PickerPromptPrefix' }
+    G.TelescopeMultiIcon = { link = 'PickerMultiIcon' }
+    G.TelescopeMultiSelection = { link = 'PickerMultiSelection' }
 
     return G
 end

--- a/lua/nordic/groups/native.lua
+++ b/lua/nordic/groups/native.lua
@@ -169,6 +169,48 @@ function M.get_groups()
     G.CmpKindValue = { link = 'Constant' }
     G.CmpKindVariable = { fg = C.cyan.base }
 
+    -- Picker Groups (shared by Telescope and Snacks picker integrations)
+    G.PickerNormal = { bg = C.bg }
+    G.PickerPromptNormal = { bg = C.bg }
+    G.PickerResultsNormal = { bg = C.bg }
+    G.PickerPreviewNormal = { bg = C.bg }
+    G.PickerPreviewLine = { bg = C.gray2 }
+    G.PickerSelection = { bg = C.bg, fg = C.yellow.bright, bold = false }
+    G.PickerSelectionCaret = { fg = C.yellow.bright, bg = C.bg, bold = true }
+    G.PickerPreviewTitle = { fg = C.white0, bg = C.bg, bold = true }
+    G.PickerResultsTitle = { fg = C.white0, bg = C.bg, bold = true }
+    G.PickerPromptTitle = { fg = C.white0, bg = C.bg, bold = true }
+    G.PickerTitle = { fg = C.white0, bg = C.bg, bold = true }
+    G.PickerBorder = { fg = C.white0, bg = C.bg }
+    G.PickerPromptBorder = { fg = C.white0, bg = C.bg }
+    G.PickerResultsBorder = { fg = C.white0, bg = C.bg }
+    G.PickerPreviewBorder = { fg = C.white0, bg = C.bg }
+    G.PickerMatching = { fg = C.orange.base, bold = true }
+    G.PickerPromptPrefix = { bg = C.bg, fg = C.orange.bright }
+    G.PickerMultiIcon = { fg = C.yellow.bright, bg = C.bg, bold = true }
+    G.PickerMultiSelection = { bg = C.bg }
+
+    if O.picker.style == 'flat' then
+        G.PickerNormal = { bg = C.bg_float }
+        G.PickerPromptNormal = { bg = C.black2 }
+        G.PickerResultsNormal = { bg = C.bg_float }
+        G.PickerPreviewNormal = { bg = C.bg_float }
+        G.PickerSelection = { bg = C.bg_visual, fg = C.yellow.bright }
+        G.PickerSelectionCaret = { fg = C.yellow.bright, bg = C.bg_float, bold = true }
+        G.PickerPreviewTitle = { bg = C.blue2, fg = C.black0, bold = true }
+        G.PickerResultsTitle = { bg = C.orange.base, fg = C.black0, bold = true }
+        G.PickerPromptTitle = { bg = C.orange.base, fg = C.black0, bold = true }
+        G.PickerTitle = { bg = C.orange.base, fg = C.black0, bold = true }
+        G.PickerBorder = { fg = C.black0, bg = C.black0 }
+        G.PickerPromptBorder = { bg = C.black2, fg = C.black0 }
+        G.PickerResultsBorder = { bg = C.bg_float, fg = C.black0 }
+        G.PickerPreviewBorder = { bg = C.bg_float, fg = C.black0 }
+        G.PickerMultiIcon = { fg = C.yellow.bright, bg = C.bg_float, bold = true }
+        G.PickerMultiSelection = { bg = C.bg_float }
+        G.PickerPromptPrefix = { bg = C.black2, fg = C.orange.bright }
+        G.PickerPreviewLine = { bg = C.gray1 }
+    end
+
     G.Comment = { fg = C.comment, italic = O.italic_comments } -- any comment
     G.ColorColumn = { bg = C.bg_cursorline } -- used for the columns set with 'colorcolumn'
     G.Conceal = { fg = C.gray3 } -- placeholder characters substituted for concealed text (see 'conceallevel')


### PR DESCRIPTION
## Summary

Adds shared `Picker*` highlight groups in `native.lua` that both Telescope and Snacks picker integrations link to. This follows the architecture requested in #182 — matching the existing `Tree*` / `CmpKind*` patterns where shared groups are defined once and plugin-specific integrations link to them.

```
native.lua
  Picker*  (classic/flat style-aware, direct palette colors)
       |
       +---> telescope.lua      Telescope*     -> { link = 'Picker*' }
       +---> snacks_picker.lua  SnacksPicker*  -> { link = 'Picker*' }
```

## Changes

- **`native.lua`** — 19 shared `Picker*` groups with classic/flat style support (colors extracted 1:1 from existing telescope.lua — no visual change for Telescope users)
- **`telescope.lua`** — rewritten as pure links to `Picker*` groups (no direct color references or style logic)
- **`snacks_picker.lua`** — new integration mapping 17 `SnacksPicker*` groups to shared `Picker*` groups
- **`config.lua`** — new `snacks_picker` integration toggle + unified `picker.style` option
- **`compatibility.lua`** — `telescope.style` silently forwards to `picker.style` for backward compat

## Relation to #182

This implements the architecture @AlexvZyl requested in the [review of #182](https://github.com/AlexvZyl/nordic.nvim/pull/182#pullrequestreview-2813255897): shared groups in `native.lua` with both pickers linking to them, rather than Snacks linking directly to Telescope groups.

## Test plan

- [ ] `nvim --headless +q` exits cleanly
- [ ] Telescope picker renders identically to before (no visual regression)
- [ ] Snacks picker renders with matching Nordic colors
- [ ] Both `classic` and `flat` styles work for both pickers
- [ ] Setting `telescope.style` without `picker.style` still works (backward compat)